### PR TITLE
Fixed off by one and other issues (affecting models, log-likelihood computation and predictions).

### DIFF
--- a/easy_tpp/config_factory/model_config.py
+++ b/easy_tpp/config_factory/model_config.py
@@ -202,9 +202,9 @@ class ModelConfig(Config):
         self.time_emb_size = kwargs.get('time_emb_size', 16)
         self.num_layers = kwargs.get('num_layers', 2)
         self.num_heads = kwargs.get('num_heads', 2)
-        self.mc_num_sample_per_step = kwargs.get('mc_num_sample_per_step', 20)
         self.sharing_param_layer = kwargs.get('sharing_param_layer', False)
-        self.loss_integral_num_sample_per_step = kwargs.get('loss_integral_num_sample_per_step', 20)
+        self.use_mc_samples = kwargs.get('use_mc_samples', True)  # if using MC samples in computing log-likelihood
+        self.loss_integral_num_sample_per_step = kwargs.get('loss_integral_num_sample_per_step', 20)  # mc_num_sample_per_step
         self.dropout_rate = kwargs.get('dropout_rate', 0.0)
         self.use_ln = kwargs.get('use_ln', False)
         self.thinning = ThinningConfig.parse_from_yaml_config(kwargs.get('thinning'))
@@ -227,7 +227,6 @@ class ModelConfig(Config):
                 'hidden_size': self.hidden_size,
                 'time_emb_size': self.time_emb_size,
                 'num_layers': self.num_layers,
-                'mc_num_sample_per_step': self.mc_num_sample_per_step,
                 'sharing_param_layer': self.sharing_param_layer,
                 'loss_integral_num_sample_per_step': self.loss_integral_num_sample_per_step,
                 'dropout_rate': self.dropout_rate,
@@ -265,7 +264,6 @@ class ModelConfig(Config):
                            hidden_size=self.hidden_size,
                            time_emb_size=self.time_emb_size,
                            num_layers=self.num_layers,
-                           mc_num_sample_per_step=self.mc_num_sample_per_step,
                            sharing_param_layer=self.sharing_param_layer,
                            loss_integral_num_sample_per_step=self.loss_integral_num_sample_per_step,
                            dropout_rate=self.dropout_rate,

--- a/easy_tpp/model/torch_model/torch_attnhp.py
+++ b/easy_tpp/model/torch_model/torch_attnhp.py
@@ -3,7 +3,7 @@ import math
 import torch
 from torch import nn
 
-from easy_tpp.model.torch_model.torch_baselayer import EncoderLayer, MultiHeadAttention
+from easy_tpp.model.torch_model.torch_baselayer import EncoderLayer, MultiHeadAttention, ScaledSoftplus
 from easy_tpp.model.torch_model.torch_basemodel import TorchBaseModel
 
 
@@ -52,7 +52,7 @@ class AttNHP(TorchBaseModel):
         if self.use_norm:
             self.norm = nn.LayerNorm(self.d_model)
         self.inten_linear = nn.Linear(self.d_model * self.n_head, self.num_event_types)
-        self.softplus = nn.Softplus()
+        self.softplus = ScaledSoftplus(self.num_event_types)  # learnable mark-specific beta
         self.layer_event_emb = nn.Linear(self.d_model + self.d_time, self.d_model)
         self.layer_intensity = nn.Sequential(self.inten_linear, self.softplus)
         self.eps = torch.finfo(torch.float32).eps
@@ -151,7 +151,7 @@ class AttNHP(TorchBaseModel):
             a diagonal matrix, [batch_size, seq_len, seq_len]
         """
         # [batch_size, seq_len, seq_len]
-        layer_mask = (torch.eye(attention_mask.size(1)) < 1).unsqueeze(0).expand_as(attention_mask).to(attention_mask.device)
+        layer_mask = (torch.eye(attention_mask.size(1), device=self.device) < 1).unsqueeze(0).expand_as(attention_mask)
         return layer_mask
 
     def make_combined_att_mask(self, attention_mask, layer_mask):
@@ -205,11 +205,11 @@ class AttNHP(TorchBaseModel):
         Returns:
             list: loglike loss, num events.
         """
-        time_seqs, time_delta_seqs, type_seqs, batch_non_pad_mask, attention_mask, type_mask = batch
+        time_seqs, time_delta_seqs, type_seqs, batch_non_pad_mask, attention_mask = batch
         # 1. compute event-loglik
         # the prediction of last event has no label, so we proceed to the last but one
         # att mask => diag is False, not mask.
-        enc_out = self.forward(time_seqs[:, :-1], type_seqs[:, :-1], attention_mask[:, 1:, :-1], time_seqs[:, 1:])
+        enc_out = self.forward(time_seqs[:, :-1], type_seqs[:, :-1], attention_mask[:, :-1, :-1], time_seqs[:, 1:])
         # [batch_size, seq_len, num_event_types]
         lambda_at_event = self.layer_intensity(enc_out)
 
@@ -227,17 +227,16 @@ class AttNHP(TorchBaseModel):
                                                                    time_delta_seqs[:, :-1],  # not used
                                                                    type_seqs[:, :-1],
                                                                    sample_times,
-                                                                   attention_mask=attention_mask[:, 1:, :-1])
+                                                                   attention_mask=attention_mask[:, :-1, :-1])
 
         event_ll, non_event_ll, num_events = self.compute_loglikelihood(lambda_at_event=lambda_at_event,
                                                                         lambdas_loss_samples=lambda_t_sample,
                                                                         time_delta_seq=time_delta_seqs[:, 1:],
                                                                         seq_mask=batch_non_pad_mask[:, 1:],
-                                                                        lambda_type_mask=type_mask[:, 1:])
+                                                                        type_seq=type_seqs[:, 1:])
 
-        # return enc_inten to compute accuracy
+        # compute loss to minimize
         loss = - (event_ll - non_event_ll).sum()
-
         return loss, num_events
 
     def compute_states_at_sample_times(self,
@@ -285,7 +284,7 @@ class AttNHP(TorchBaseModel):
         encoder_output = encoder_output.permute((1, 2, 0, 3))
         return encoder_output
 
-    def compute_intensities_at_sample_times(self, time_seqs, time_delta_seqs, type_seqs, sample_times, **kwargs):
+    def compute_intensities_at_sample_times(self, time_seqs, time_delta_seqs, type_seqs, sample_dtimes, **kwargs):
         """Compute the intensity at sampled times.
 
         Args:
@@ -302,17 +301,17 @@ class AttNHP(TorchBaseModel):
 
         if attention_mask is None:
             batch_size, seq_len = time_seqs.size()
-            attention_mask = torch.triu(torch.ones(seq_len, seq_len), diagonal=1).unsqueeze(0)
-            attention_mask = attention_mask.expand(batch_size, -1, -1).to(torch.bool).to(time_seqs.device)
+            attention_mask = torch.triu(torch.ones(seq_len, seq_len), diagonal=1).unsqueeze(0).to(type_seqs.device)
+            attention_mask = attention_mask.expand(batch_size, -1, -1).to(torch.bool)
 
-        if sample_times.size()[1] < time_seqs.size()[1]:
+        if sample_dtimes.size()[1] < time_seqs.size()[1]:
             # we pass sample_dtimes for last time step here
             # we do a temp solution
             # [batch_size, seq_len, num_samples]
-            sample_times = time_seqs[:, :, None] + torch.tile(sample_times, [1, time_seqs.size()[1], 1])
+            sample_dtimes = time_seqs[:, :, None] + torch.tile(sample_dtimes, [1, time_seqs.size()[1], 1])
 
         # [batch_size, seq_len, num_samples, hidden_size]
-        encoder_output = self.compute_states_at_sample_times(time_seqs, type_seqs, attention_mask, sample_times)
+        encoder_output = self.compute_states_at_sample_times(time_seqs, type_seqs, attention_mask, sample_dtimes)
 
         if compute_last_step_only:
             lambdas = self.layer_intensity(encoder_output[:, -1:, :, :])

--- a/easy_tpp/model/torch_model/torch_basemodel.py
+++ b/easy_tpp/model/torch_model/torch_basemodel.py
@@ -2,6 +2,7 @@
 
 import torch
 from torch import nn
+from torch.nn import functional as F
 
 from easy_tpp.model.torch_model.torch_thinning import EventSampler
 from easy_tpp.utils import set_device
@@ -29,6 +30,7 @@ class TorchBaseModel(nn.Module):
         self.gen_config = model_config.thinning
         self.event_sampler = None
         self.device = set_device(model_config.gpu)
+        self.use_mc_samples = model_config.use_mc_samples
 
         self.to(self.device)
 
@@ -81,8 +83,7 @@ class TorchBaseModel(nn.Module):
         last_logits = torch.gather(logits, dim=1, index=select_index).squeeze(1)
         return last_logits
 
-    def compute_loglikelihood(self, time_delta_seq, lambda_at_event, lambdas_loss_samples, seq_mask,
-                              lambda_type_mask):
+    def compute_loglikelihood(self, time_delta_seq, lambda_at_event, lambdas_loss_samples, seq_mask, type_seq):
         """Compute the loglikelihood of the event sequence based on Equation (8) of NHP paper.
 
         Args:
@@ -92,38 +93,35 @@ class TorchBaseModel(nn.Module):
             lambdas_loss_samples (tensor): [batch_size, seq_len, num_sample, num_event_types],
             intensity at sampling times.
             seq_mask (tensor): [batch_size, seq_len], sequence mask vector to mask the padded events.
-            lambda_type_mask (tensor): [batch_size, seq_len, num_event_types], type mask matrix to mask the
-            padded event types.
+            type_seq (tensor): [batch_size, seq_len], sequence of mark ids, with padded events having a mark of self.pad_token_id
 
         Returns:
             tuple: event loglike, non-event loglike, intensity at event with padding events masked
         """
 
-        # Sum of lambda over every type and every event point
-        # [batch_size, seq_len]
-        event_lambdas = torch.sum(lambda_at_event * lambda_type_mask, dim=-1) + self.eps
+        # First, add an epsilon to every marked intensity for stability
+        lambda_at_event = lambda_at_event + self.eps
+        lambdas_loss_samples = lambdas_loss_samples + self.eps
 
-        # mask the pad event
-        event_lambdas = event_lambdas.masked_fill_(~seq_mask, 1.0)
+        log_marked_event_lambdas = lambda_at_event.log()
+        total_sampled_lambdas = lambdas_loss_samples.sum(dim=-1)
 
-        # [batch_size, seq_len)
-        event_ll = torch.log(event_lambdas)
+        # Compute event LL - [batch_size, seq_len]
+        event_ll = -F.nll_loss(
+            log_marked_event_lambdas.permute(0, 2, 1),  # mark dimension needs to come second, not third to match nll_loss specs
+            target=type_seq,
+            ignore_index=self.pad_token_id,  # Padded events have a pad_token_id as a value
+            reduction='none', # Does not aggregate, and replaces what would have been the log(marked intensity) with 0.
+        )
 
-        # Compute the big lambda integral in equation (8) of NHP paper
-        # 1 - take num_mc_sample rand points in each event interval
-        # 2 - compute its lambda value for every sample point
-        # 3 - take average of these sample points
-        # 4 - times the interval length
-
-        # [batch_size, seq_len, n_loss_sample]
-        lambdas_total_samples = lambdas_loss_samples.sum(dim=-1)
-
-        # interval_integral - [batch_size, seq_len]
+        # Compute non-event LL [batch_size, seq_len]
         # interval_integral = length_interval * average of sampled lambda(t)
-        non_event_ll = lambdas_total_samples.mean(dim=-1) * time_delta_seq * seq_mask
+        if self.use_mc_samples:
+            non_event_ll = total_sampled_lambdas.mean(dim=-1) * time_delta_seq * seq_mask
+        else: # Use trapezoid rule
+            non_event_ll = 0.5 * (total_sampled_lambdas[..., 1:] + total_sampled_lambdas[..., :-1]).mean(dim=-1) * time_delta_seq * seq_mask
 
         num_events = torch.masked_select(event_ll, event_ll.ne(0.0)).size()[0]
-
         return event_ll, non_event_ll, num_events
 
     def make_dtime_loss_samples(self, time_delta_seq):

--- a/easy_tpp/model/torch_model/torch_intensity_free.py
+++ b/easy_tpp/model/torch_model/torch_intensity_free.py
@@ -121,11 +121,14 @@ class IntensityFree(TorchBaseModel):
         super(IntensityFree, self).__init__(model_config)
 
         self.num_mix_components = model_config.model_specs['num_mix_components']
+        self.mean_log_inter_time = model_config.get("mean_log_inter_time", 0.0)
+        self.std_log_inter_time = model_config.get("std_log_inter_time", 1.0)
+
         self.num_features = 1 + self.hidden_size
 
         self.layer_rnn = nn.GRU(input_size=self.num_features,
                                 hidden_size=self.hidden_size,
-                                num_layers=1,
+                                num_layers=1,  # used in original paper
                                 batch_first=True)
 
         self.mark_linear = nn.Linear(self.hidden_size, self.num_event_types_pad)
@@ -165,15 +168,10 @@ class IntensityFree(TorchBaseModel):
         Returns:
             tuple: loglikelihood loss and num of events.
         """
-        time_seqs, time_delta_seqs, type_seqs, batch_non_pad_mask, _, type_mask = batch
-
-        mean_log_inter_time = \
-            torch.masked_select(time_delta_seqs[:, 1:], batch_non_pad_mask[:, 1:]).clamp(1e-5).log().mean()
-        std_log_inter_time = \
-            torch.masked_select(time_delta_seqs[:, 1:], batch_non_pad_mask[:, 1:]).clamp(1e-5).log().std()
+        time_seqs, time_delta_seqs, type_seqs, batch_non_pad_mask, _ = batch
 
         # [batch_size, seq_len, hidden_size]
-        context = self.forward(time_delta_seqs[:, 1:], type_seqs[:, :-1])
+        context = self.forward(time_delta_seqs[:, :-1], type_seqs[:, :-1])
 
         # [batch_size, seq_len, 3 * num_mix_components]
         raw_params = self.linear(context)
@@ -187,32 +185,70 @@ class IntensityFree(TorchBaseModel):
             locs=locs,
             log_scales=log_scales,
             log_weights=log_weights,
-            mean_log_inter_time=mean_log_inter_time,
-            std_log_inter_time=std_log_inter_time
+            mean_log_inter_time=self.mean_log_inter_time,
+            std_log_inter_time=self.std_log_inter_time
         )
 
         inter_times = time_delta_seqs[:, 1:].clamp(min=1e-5)
         # [batch_size, seq_len]
-        log_p = inter_time_dist.log_prob(inter_times)
-
-        # i comment these lines
-        # (batch_size, 1)
-        # last_event_idx = batch_non_pad_mask.sum(-1, keepdim=True).long() - 1
-        # log_surv_all = inter_time_dist.log_survival_function(inter_times)
-        # (batch_size,)
-        # log_surv_last = torch.gather(log_surv_all, dim=-1, index=last_event_idx).squeeze(-1)
+        event_mask = torch.logical_and(batch_non_pad_mask[:, 1:], type_seqs[:, 1:] != self.pad_token_id)
+        time_ll = inter_time_dist.log_prob(inter_times) * event_mask
 
         # [batch_size, seq_len, num_marks]
         mark_logits = torch.log_softmax(self.mark_linear(context), dim=-1)
         mark_dist = Categorical(logits=mark_logits)
-        log_p += mark_dist.log_prob(type_seqs[:, :-1])
+        mark_ll = mark_dist.log_prob(type_seqs[:, 1:]) * event_mask
 
-        # [batch_size, seq_len]
-        log_p *= batch_non_pad_mask[:, 1:]
+        log_p = time_ll + mark_ll
 
         # [batch_size,]
-        loss = -(log_p.sum(-1)).mean()
+        loss = -log_p.sum()
 
-        num_events = torch.masked_select(batch_non_pad_mask[:, 1:], batch_non_pad_mask[:, 1:]).size()[0]
+        num_events = event_mask.sum().item()
 
         return loss, num_events
+
+    def predict_one_step_at_every_event(self, batch):
+        """One-step prediction for every event in the sequence.
+
+        Args:
+            time_seqs (tensor): [batch_size, seq_len].
+            time_delta_seqs (tensor): [batch_size, seq_len].
+            type_seqs (tensor): [batch_size, seq_len].
+
+        Returns:
+            tuple: tensors of dtime and type prediction, [batch_size, seq_len].
+        """
+        time_seq, time_delta_seq, event_seq, batch_non_pad_mask, _ = batch
+
+        # remove the last event, as the prediction based on the last event has no label
+        # time_delta_seq should start from 1, because the first one is zero
+        time_seq, time_delta_seq, event_seq = time_seq[:, :-1], time_delta_seq[:, :-1], event_seq[:, :-1]
+
+        # [batch_size, seq_len, hidden_size]
+        context = self.forward(time_delta_seq, event_seq)
+
+        # [batch_size, seq_len, 3 * num_mix_components]
+        raw_params = self.linear(context)
+        locs = raw_params[..., :self.num_mix_components]
+        log_scales = raw_params[..., self.num_mix_components: (2 * self.num_mix_components)]
+        log_weights = raw_params[..., (2 * self.num_mix_components):]
+
+        log_scales = clamp_preserve_gradients(log_scales, -5.0, 3.0)
+        log_weights = torch.log_softmax(log_weights, dim=-1)
+        inter_time_dist = LogNormalMixtureDistribution(
+            locs=locs,
+            log_scales=log_scales,
+            log_weights=log_weights,
+            mean_log_inter_time=self.mean_log_inter_time,
+            std_log_inter_time=self.std_log_inter_time
+        )
+
+        # [num_samples, batch_size, seq_len]
+        accepted_dtimes = inter_time_dist.sample((self.event_sampler.num_sample,))
+        dtimes_pred = accepted_dtimes.mean(dim=0)
+
+        # [batch_size, seq_len, num_marks]
+        mark_logits = torch.log_softmax(self.mark_linear(context), dim=-1)  # Marks are modeled conditionally independently from times
+        types_pred = torch.argmax(mark_logits, dim=-1)
+        return dtimes_pred, types_pred

--- a/easy_tpp/model/torch_model/torch_rmtpp.py
+++ b/easy_tpp/model/torch_model/torch_rmtpp.py
@@ -1,8 +1,8 @@
 import torch
 from torch import nn
+import math
 
 from easy_tpp.model.torch_model.torch_basemodel import TorchBaseModel
-
 
 class RMTPP(TorchBaseModel):
     """Torch implementation of Recurrent Marked Temporal Point Processes, KDD 2016.
@@ -18,71 +18,47 @@ class RMTPP(TorchBaseModel):
         super(RMTPP, self).__init__(model_config)
 
         self.layer_temporal_emb = nn.Linear(1, self.hidden_size)
-
         self.layer_rnn = nn.RNN(input_size=self.hidden_size, hidden_size=self.hidden_size,
                                 num_layers=1, batch_first=True)
 
-        self.layer_hidden = nn.Linear(self.hidden_size, self.num_event_types)
+        self.hidden_to_intensity_logits = nn.Linear(self.hidden_size, self.num_event_types)
+        self.b_t = nn.Parameter(torch.zeros(1, self.num_event_types))
+        self.w_t = nn.Parameter(torch.zeros(1, self.num_event_types))
+        nn.init.xavier_normal_(self.b_t)
+        nn.init.xavier_normal_(self.w_t)
 
-        self.factor_intensity_base = torch.nn.Parameter(torch.empty([1, 1, self.num_event_types], device=self.device))
-        self.factor_intensity_current_influence = torch.nn.Parameter(torch.empty([1, 1, self.num_event_types], device=self.device))
+    def evolve_and_get_intentsity(self, right_hiddens_BNH, dts_BNG):
+        """
+        Eq.11 that computes intensity.
+        """
+        past_influence_BNGM = self.hidden_to_intensity_logits(right_hiddens_BNH[..., None, :])
+        intensity_BNGM = (past_influence_BNGM + self.w_t[None, None, :] * dts_BNG[..., None]
+                         + self.b_t[None, None, :]).clamp(max=math.log(1e5)).exp()
+        return intensity_BNGM
 
-        nn.init.xavier_normal_(self.factor_intensity_base)
-        nn.init.xavier_normal_(self.factor_intensity_current_influence)
+    def forward(self, batch):
+        """
+        Suppose we have inputs with original sequence length N+1
+        ts: [t0, t1, ..., t_N]
+        dts: [0, t1 - t0, t2 - t1, ..., t_N - t_{N-1}]
+        marks: [k0, k1, ..., k_N] (k0 and kN could be padded marks if t0 and tN correspond to left and right windows)
 
-    def state_decay(self, states_to_decay, duration_t):
-        """Equation (11), which computes intensity
+        Return:
+            left limits of *intensity* at [t_1, ..., t_N] of shape: (batch_size, seq_len - 1, hidden_dim)
+            right limits of *hidden states* [t_0, ..., t_{N-1}, t_N] of shape: (batch_size, seq_len, hidden_dim)
+            We need the right limit of t_N to sample continuation.
         """
 
-        # [batch_size, seq_len, num_event_types]
-        states_to_decay_ = self.layer_hidden(states_to_decay)
+        t_BN, dt_BN, marks_BN, _, _ = batch
+        mark_emb_BNH = self.layer_type_emb(marks_BN)
+        time_emb_BNH = self.layer_temporal_emb(t_BN[..., None])
+        right_hiddens_BNH, _ = self.layer_rnn(mark_emb_BNH + time_emb_BNH)
+        left_intensity_B_Nm1_M = self.evolve_and_get_intentsity(right_hiddens_BNH[:, :-1, :], dt_BN[:, 1:][...,None]).squeeze(-2)
+        return left_intensity_B_Nm1_M, right_hiddens_BNH
 
-        # [batch_size, seq_len, num_event_types]
-        # put a max number to avoid explode during HPO
-        intensity = torch.exp(
-            states_to_decay_ + self.factor_intensity_current_influence * duration_t +
-            self.factor_intensity_base).clamp(max=1e5)
-        return intensity
-
-    def forward(self, time_seqs, time_delta_seqs, type_seqs, **kwargs):
-        """Call the model.
-
-        Args:
-            batch (list): batch input.
-
-        Returns:
-            list: hidden states, [batch_size, seq_len, hidden_dim], states right before the event happens;
-                  stacked decay states,  [batch_size, max_seq_length, 4, hidden_dim], states right after
-                  the event happens.
-        """
-
-        max_steps = kwargs.get('max_steps', None)
-
-        # last event has no time label
-        max_seq_length = max_steps if max_steps is not None else type_seqs.size(1) - 1
-
-        # [batch_size, seq_len, hidden_size]
-        type_emb = self.layer_type_emb(type_seqs)
-
-        # [batch_size, seq_len, hidden_size]
-        temporal_emb = self.layer_temporal_emb(time_seqs[..., None])
-
-        # [batch_size, seq_len, hidden_size]
-        # states right after the event
-        decay_states, _ = self.layer_rnn(type_emb + temporal_emb)
-
-        # if only one event, then we dont decay
-        if max_seq_length == 1:
-            h_t = decay_states
-        else:
-            # States decay - Equation (7) in the paper
-            # states before the happening of the next event
-            h_t = self.state_decay(decay_states, time_delta_seqs[..., None])
-
-        return h_t, decay_states
 
     def loglike_loss(self, batch):
-        """Compute the loglike loss.
+        """Compute the log-likelihood loss.
 
         Args:
             batch (list): batch input.
@@ -90,59 +66,32 @@ class RMTPP(TorchBaseModel):
         Returns:
             tuple: loglikelihood loss and num of events.
         """
-        time_seqs, time_delta_seqs, type_seqs, batch_non_pad_mask, _, type_mask = batch
+        ts_BN, dts_BN, marks_BN, batch_non_pad_mask, _ = batch
 
-        lambda_at_event, decay_states = self.forward(time_seqs[:, :-1], time_delta_seqs[:, 1:], type_seqs[:, :-1])
+        # compute left intensity and hidden states at event time
+        # left limits of intensity at [t_1, ..., t_N]
+        # right limits of hidden states at [t_0, ..., t_{N-1}, t_N]
+        left_intensity_B_Nm1_M, right_hiddens_BNH = self.forward((ts_BN, dts_BN, marks_BN, None, None))
+        right_hiddens_B_Nm1_H = right_hiddens_BNH[..., :-1, :]  # discard right limit at t_N for logL
 
-        # Num of samples in each batch and num of event time point in the sequence
-        batch_size, seq_len, _ = lambda_at_event.size()
+        dts_sample_B_Nm1_G = self.make_dtime_loss_samples(dts_BN[:, 1:])
+        intensity_dts_B_Nm1_G_M = self.evolve_and_get_intentsity(right_hiddens_B_Nm1_H, dts_sample_B_Nm1_G)
 
-        # Compute the big lambda integral in equation (8)
-        # 1 - take num_mc_sample rand points in each event interval
-        # 2 - compute its lambda value for every sample point
-        # 3 - take average of these sample points
-        # 4 - times the interval length
+        event_ll, non_event_ll, num_events = self.compute_loglikelihood(
+            lambda_at_event=left_intensity_B_Nm1_M,
+            lambdas_loss_samples=intensity_dts_B_Nm1_G_M,
+            time_delta_seq=dts_BN[:, 1:],
+            seq_mask=batch_non_pad_mask[:, 1:],
+            type_seq=marks_BN[:, 1:]
+        )
 
-        # interval_t_sample - [batch_size, num_times=max_len-1, num_mc_sample]
-        # for every batch and every event point => do a sampling (num_mc_sampling)
-        # the first dtime is zero, so we use time_delta_seqs[:, 1:]
-        interval_t_sample = self.make_dtime_loss_samples(time_delta_seqs[:, 1:])
-
-        # [batch_size, num_times = max_len - 1, num_sample, event_num]
-        lambda_t_sample = self.compute_states_at_sample_times(decay_states, interval_t_sample)
-
-        event_ll, non_event_ll, num_events = self.compute_loglikelihood(lambda_at_event=lambda_at_event,
-                                                                        lambdas_loss_samples=lambda_t_sample,
-                                                                        time_delta_seq=time_delta_seqs[:, 1:],
-                                                                        seq_mask=batch_non_pad_mask[:, 1:],
-                                                                        lambda_type_mask=type_mask[:, 1:])
-
-        # (num_samples, num_times)
+        # compute loss to minimize
         loss = - (event_ll - non_event_ll).sum()
         return loss, num_events
 
-    def compute_states_at_sample_times(self, decay_states, sample_dtimes):
-        """Compute the hidden states at sampled times.
 
-        Args:
-            decay_states (tensor): [batch_size, seq_len, hidden_size].
-            sample_dtimes (tensor): [batch_size, seq_len, num_samples].
 
-        Returns:
-            tensor: hidden state at each sampled time.
-        """
-        # update the states given last event
-
-        # Use broadcasting to compute the decays at all time steps
-        # decay_states[..., None, :]: [batch_size, seq_len, 1, hidden_size]
-        # sample_dtimes[..., None]: [batch_size, seq_len, num_mc_sample, 1]
-        # h_ts shape (batch_size, num_times, num_mc_sample, hidden_dim)
-        h_ts = self.state_decay(decay_states[..., None, :],
-                                sample_dtimes[..., None])
-
-        return h_ts
-
-    def compute_intensities_at_sample_times(self, time_seqs, time_delta_seqs, type_seqs, sample_times, **kwargs):
+    def compute_intensities_at_sample_times(self, time_seqs, time_delta_seqs, type_seqs, sample_dtimes, **kwargs):
         """Compute the intensity at sampled times, not only event times.
 
         Args:
@@ -158,26 +107,11 @@ class RMTPP(TorchBaseModel):
 
         compute_last_step_only = kwargs.get('compute_last_step_only', False)
 
-        # forward to the last but one event
-        _, decay_states = self.forward(time_seqs, time_delta_seqs, type_seqs, **kwargs)
-
-        # Num of samples in each batch and num of event time point in the sequence
-        batch_size, seq_len, _ = decay_states.size()
+        _input = time_seqs, time_delta_seqs, type_seqs, None, None
+        _, right_hiddens_BNH = self.forward(_input)
 
         if compute_last_step_only:
-            interval_t_sample = sample_times[:, -1:, :, None]
-            # [batch_size, 1, num_mc_sample, num_event_types]
-            sampled_intensities = self.state_decay(decay_states[:, -1:, None, :],
-                                                   interval_t_sample)
-
+            sampled_intensities = self.evolve_and_get_intentsity(right_hiddens_BNH[:, -1:, :], sample_dtimes[:, -1:, :])
         else:
-            # interval_t_sample - [batch_size, num_times, num_mc_sample, 1]
-            interval_t_sample = sample_times[..., None]
-            # Use broadcasting to compute the decays at all time steps
-            # at all sample points
-            # sampled_intensities shape (batch_size, num_times, num_mc_sample, hidden_dim)
-            # decay_states[:, :, None, :]  (batch_size, num_times, 1, hidden_dim)
-            sampled_intensities = self.state_decay(decay_states[..., None, :],
-                                                   interval_t_sample)
-
+            sampled_intensities = self.evolve_and_get_intentsity(right_hiddens_BNH, sample_dtimes)  # shape: [B, N, G, M]
         return sampled_intensities

--- a/easy_tpp/model/torch_model/torch_thp.py
+++ b/easy_tpp/model/torch_model/torch_thp.py
@@ -1,7 +1,7 @@
 import torch
 import torch.nn as nn
 
-from easy_tpp.model.torch_model.torch_baselayer import EncoderLayer, MultiHeadAttention, TimePositionalEncoding
+from easy_tpp.model.torch_model.torch_baselayer import EncoderLayer, MultiHeadAttention, TimePositionalEncoding, ScaledSoftplus
 from easy_tpp.model.torch_model.torch_basemodel import TorchBaseModel
 
 
@@ -34,7 +34,7 @@ class THP(TorchBaseModel):
 
         # convert hidden vectors into event-type-sized vector
         self.layer_intensity_hidden = nn.Linear(self.d_model, self.num_event_types)
-        self.softplus = nn.Softplus()
+        self.softplus = ScaledSoftplus(self.num_event_types)   # learnable mark-specific beta
 
         # Add MLP layer
         # Equation (5)
@@ -49,7 +49,6 @@ class THP(TorchBaseModel):
                 self.d_model,
                 MultiHeadAttention(self.n_head, self.d_model, self.d_model, self.dropout,
                                    output_linear=False),
-
                 use_residual=False,
                 feed_forward=self.feed_forward,
                 dropout=self.dropout
@@ -88,11 +87,11 @@ class THP(TorchBaseModel):
         Returns:
             tuple: loglike loss, num events.
         """
-        time_seqs, time_delta_seqs, type_seqs, batch_non_pad_mask, attention_mask, type_mask = batch
+        time_seqs, time_delta_seqs, type_seqs, batch_non_pad_mask, attention_mask = batch
 
         # 1. compute event-loglik
         # [batch_size, seq_len, hidden_size]
-        enc_out = self.forward(time_seqs[:, :-1], type_seqs[:, :-1], attention_mask[:, 1:, :-1])
+        enc_out = self.forward(time_seqs[:, :-1], type_seqs[:, :-1], attention_mask[:, :-1, :-1])
 
         # [batch_size, seq_len, num_event_types]
         # update time decay based on Equation (6)
@@ -122,11 +121,10 @@ class THP(TorchBaseModel):
                                                                         lambdas_loss_samples=lambda_t_sample,
                                                                         time_delta_seq=time_delta_seqs[:, 1:],
                                                                         seq_mask=batch_non_pad_mask[:, 1:],
-                                                                        lambda_type_mask=type_mask[:, 1:])
+                                                                        type_seq=type_seqs[:, 1:])
 
-        # return enc_inten to compute accuracy
+        # compute loss to minimize
         loss = - (event_ll - non_event_ll).sum()
-
         return loss, num_events
 
     def compute_states_at_sample_times(self, event_states, sample_dtimes):

--- a/easy_tpp/runner/base_runner.py
+++ b/easy_tpp/runner/base_runner.py
@@ -38,6 +38,12 @@ class Runner(Registrable):
                 backend=backend,
                 **kwargs
             )
+
+        # Needed for Intensity Free model
+        mean_log_inter_time, std_log_inter_time, min_dt, max_dt = (
+            self._data_loader.train_loader().dataset.get_dt_stats())
+        runner_config.model_config.set("mean_log_inter_time", mean_log_inter_time)
+        runner_config.model_config.set("std_log_inter_time", std_log_inter_time)
         self.timer = Timer()
 
     @staticmethod

--- a/easy_tpp/torch_wrapper.py
+++ b/easy_tpp/torch_wrapper.py
@@ -125,14 +125,15 @@ class TorchModelWrapper:
                 self.opt.step()
             else:  # by default we do not do evaluation on train set which may take a long time
                 if self.model.event_sampler:
-                    if batch[1] is not None and batch[2] is not None:
-                        label_dtime, label_type = batch[1][:, 1:].cpu().numpy(), batch[2][:, 1:].cpu().numpy()
-                    if batch[3] is not None:
-                        mask = batch[3][:, 1:].cpu().numpy()
-                    pred_dtime, pred_type = self.model.predict_one_step_at_every_event(batch=batch)
-                    pred_dtime = pred_dtime.detach().cpu().numpy()
-                    pred_type = pred_type.detach().cpu().numpy()
-
+                    self.model.eval()
+                    with torch.no_grad():
+                        if batch[1] is not None and batch[2] is not None:
+                            label_dtime, label_type = batch[1][:, 1:].cpu().numpy(), batch[2][:, 1:].cpu().numpy()
+                        if batch[3] is not None:
+                            mask = batch[3][:, 1:].cpu().numpy()
+                        pred_dtime, pred_type = self.model.predict_one_step_at_every_event(batch=batch)
+                        pred_dtime = pred_dtime.detach().cpu().numpy()
+                        pred_type = pred_type.detach().cpu().numpy()
             return loss.item(), num_event, (pred_dtime, pred_type), (label_dtime, label_type), (mask,)
         else:
             pred_dtime, pred_type, label_dtime, label_type = self.model.predict_multi_step_since_last_event(batch=batch)


### PR DESCRIPTION
1. Fixed the off-by-one issue in computing log-likelihood, mainly due to inconsistent shifting of inter-event times (dts) for each model. Details are explained in each commit comment.
2. Fixed the next event prediction of marks with multiple accepted sampled times, and the off-by-one issue due to inconsistent shifting of inter-event times (dts).
3. When computing log-likelihood, we updated the integral estimate using the trapezoid rule because the last grid point on each interval always overlaps with the left intensity at event time. We added the option to use unbiased Monte Carlo samples in integral estimates. We directly used the mark sequences to compute `event_ll`  to be more memory efficient, so it can be extended to higher dimensional mark space. 
4. Other changes to models:
  - We fixed IFTPP with data leakage and incorrect scaling of log-likelihood and allowed it to sample from the parameterized distribution. 
  - We added mark-specific Softplus parameters for several models to be consistent with the original papers (NHP, THP, SAHP, AttNHP).
  - We added marked intensities for FullyNN.
  - RMTPP and NHP are refactored for simpler implementations (and to be consistent with the above changes).

All these changes are made collaboratively with @ajboyd2.
