### PR TITLE
Add a thinning config to IntensityFree_train in YAML config

### DIFF
--- a/examples/configs/experiment_config.yaml
+++ b/examples/configs/experiment_config.yaml
@@ -255,7 +255,16 @@ IntensityFree_train:
     use_ln: False
     model_specs:
       num_mix_components: 3
-
+    thinning:
+      num_seq: 10
+      num_sample: 1
+      num_exp: 500 # number of i.i.d. Exp(intensity_bound) draws at one time in thinning algorithm
+      look_ahead_time: 10
+      patience_counter: 5 # the maximum iteration used in adaptive thinning
+      over_sample_rate: 5
+      num_samples_boundary: 5
+      dtime_max: 5
+      num_step_gen: 1
 
 
 ODETPP_train:


### PR DESCRIPTION
## Description
This PR resolves the evaluation metrics issue in `IntensityFree_train` identified in #51 by adding a thinning configuration. 

### Problem
As reported in #51, the current implementation doesn't output accuracy and RMSE metrics for IntensityFree models because:
1. Evaluation only triggers when an `event_sampler` is defined ([torch_wrapper.py#L126](https://github.com/ant-research/EasyTemporalPointProcess/blob/main/easy_tpp/torch_wrapper.py#L126))
2. The `predict_one_step_at_every_event` method is overridden in IFTPP ([torch_intensityfree.py#L211](https://github.com/ant-research/EasyTemporalPointProcess/blob/main/easy_tpp/model/torch_model/torch_intensity_free.py#L211)) without requiring an event sampler

### Solution
Added a thinning configuration to `IntensityFree_train` in YAML config.

### Testing
I've verified that after this change, accuracy and RMSE metrics are properly computed.
