### PR TITLE
Patch for illegal memory access error when using cuda:device!=0

### DIFF
--- a/easy_tpp/torch_wrapper.py
+++ b/easy_tpp/torch_wrapper.py
@@ -20,8 +20,12 @@ class TorchModelWrapper:
         self.base_config = base_config
         self.model_config = model_config
         self.trainer_config = trainer_config
-
+        
         self.model_id = self.base_config.model_id
+        # Sometimes PyTorch may not switch the active device context for all operations
+        # This causes illegal memory access error
+        if self.trainer_config.gpu!=-1:
+            torch.cuda.set_device(self.trainer_config.gpu)
         self.device = set_device(self.trainer_config.gpu)
 
         self.model.to(self.device)


### PR DESCRIPTION
 Sometimes PyTorch may not switch the active device context for all operations. This causes illegal memory access error especially when using cuda devices other than device:0

I added a line to set the device across all torch context taking into consideration when user decides to use cpu (config.gpu=-1)